### PR TITLE
Delete sigmoid function at the output layer

### DIFF
--- a/notebooks/mlp_mnist_simple.ipynb
+++ b/notebooks/mlp_mnist_simple.ipynb
@@ -78,7 +78,7 @@
     "def multilayer_perceptron(_X, _weights, _biases):\n",
     "    layer_1 = tf.nn.sigmoid(tf.add(tf.matmul(_X, _weights['h1']), _biases['b1'])) \n",
     "    layer_2 = tf.nn.sigmoid(tf.add(tf.matmul(layer_1, _weights['h2']), _biases['b2']))\n",
-    "    return (tf.sigmoid(tf.matmul(layer_2, _weights['out']) + _biases['out']))\n",
+    "    return (tf.matmul(layer_2, _weights['out']) + _biases['out'])\n",
     "    \n",
     "# Store layers weight & bias\n",
     "stddev = 0.1 # <== This greatly affects accuracy!! \n",


### PR DESCRIPTION
Since `softmax_cross_entropy_with_logits` already contains softmax function at the output layer, 
I deleted the sigmoid at the output layer
